### PR TITLE
perf: skip embedding for documents already in Qdrant

### DIFF
--- a/ragstuffer.py
+++ b/ragstuffer.py
@@ -437,7 +437,8 @@ def _get_existing_doc_ids(qdrant, collection_name: str) -> set[str]:
             )
             points, next_offset = results
             for point in points:
-                doc_ids.add(point.payload["doc_id"])
+                if doc_id := point.payload.get("doc_id"):
+                    doc_ids.add(doc_id)
             if next_offset is None:
                 break
             offset = next_offset


### PR DESCRIPTION
## Summary
- Before embedding, queries Qdrant for existing doc_ids and skips chunks that already have vectors
- Postgres upsert still runs on every cycle (cheap, idempotent, handles text updates)
- Reduces restart ingest from ~10 min GPU embedding to <1s when corpus is unchanged

## Verified
- 29,276 chunks / 66 docs: `All 29276 chunks already in Qdrant — nothing to embed` in <1s
- New documents still get embedded normally
- 85 tests pass

## Test plan
- [ ] Restart ragstuffer with existing Qdrant data — should skip all embedding
- [ ] Add a new document to Drive — should embed only the new doc
- [ ] `ingest-full` after deleting Qdrant collection — should re-embed everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document ingestion now detects and skips previously processed documents, preventing unnecessary reprocessing.

* **Refactor**
  * Optimized ingestion pipeline to embed and index only new documents, improving performance and reducing resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->