### PR TITLE
sec: add Trivy container scanning to security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,3 +55,26 @@ jobs:
         with:
           sarif_file: trivy-results-${{ matrix.variant }}.sarif
           category: trivy-${{ matrix.variant }}
+
+  codeql:
+    name: CodeQL analysis
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds aquasecurity/trivy-action to scan all three container variants (cpu, cuda, rocm) on every PR and weekly schedule. Results upload to GitHub Security tab as SARIF. Scans for CRITICAL and HIGH severity only. Existing pip-audit job retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated vulnerability scanning for container images across CPU, CUDA, and ROCM variants
  * Integrated Trivy security scanning into the continuous integration pipeline
  * Critical and high severity vulnerabilities now block build completion
  * Vulnerability reports available in GitHub Security tab for centralized visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->