### PR TITLE
chore: add container image build and publish to ghcr.io

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -45,9 +45,6 @@ jobs:
           - variant: cpu
             file: Containerfile
             suffix: ""
-          # ROCm and CUDA variants are built but not pushed in CI —
-          # they require GPU hardware for full testing. Built locally
-          # on hardware with GPU access.
           - variant: rocm
             file: Containerfile.rocm
             suffix: "-rocm"


### PR DESCRIPTION
## Summary
- Replace lint-only container workflow with full build & push pipeline
- Builds CPU, ROCm, and CUDA variants on every push to main
- Pushes to `ghcr.io/aclater/ragstuffer:{main,main-rocm,main-cuda}`
- Build-only on PRs (no push)
- Retains Hadolint lint and SBOM generation

## Test plan
- [ ] Verify CPU image builds and pushes on merge
- [ ] Verify ROCm/CUDA images build (push may fail if base image requires GPU — acceptable)
- [ ] Pull `ghcr.io/aclater/ragstuffer:main` and verify it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run on version tags and additional changed files for more comprehensive triggers.
  * Added a multi-variant container build (CPU/ROCm/CUDA) with improved image naming, metadata extraction and conditional push behavior.
  * Expanded workflow permissions to support package operations.
  * Updated CI action versions and refined checkout steps for more robust pipeline execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->