### PR TITLE
fix(quadlet): set STAGING_DIR to match volume mount (fixes #19)

### DIFF
--- a/quadlets/ragstuffer.container
+++ b/quadlets/ragstuffer.container
@@ -28,6 +28,7 @@ EnvironmentFile=%h/.config/llm-stack/env
 # Overrides — ragstuffer-specific
 Environment=GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gdrive-sa.json
 Environment=RAG_STATE_FILE=/state/rag-state.json
+Environment=STAGING_DIR=/tmp/rag-staging
 
 # Run as non-root
 User=1000


### PR DESCRIPTION
## Summary
Set `STAGING_DIR=/tmp/rag-staging` in the quadlet to match the existing volume mount `ragstuffer-staging:/tmp/rag-staging:Z`.

## Root Cause
The container had `STAGING_DIR=/staging` (from the EnvironmentFile), but:
1. `/staging` is not writable in the container (btrfs subvolume with UID mapping issues)
2. The code correctly creates `/tmp/rag-staging` if the env var is set to that path

## Testing
- After applying, the container will download files to the writable named volume instead of the non-writable `/staging`

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to define the staging directory path, ensuring proper file handling in staging operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->