### PR TITLE
fix(container): COPY application source into CPU image (fixes #25)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
-# ragstuffer — pre-built image with system packages and Python dependencies
-# Base: UBI10 (matches current quadlet)
+# ragstuffer — CPU-only image with application code baked in
+# Base: UBI10 (Red Hat Universal Base Image)
 # No embedding model — delegates to ragpipe via /v1/embeddings
 FROM registry.access.redhat.com/ubi10@sha256:1b616c4a90d6444b394d5c8f4bd9e15a394d95dd628925d0ec80c257fdc5099c
 
@@ -13,6 +13,10 @@ RUN dnf install -y -q python3 python3-pip git-core && \
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
-# App code is mounted as a volume at runtime for dev workflow
 WORKDIR /app
+COPY ragstuffer/ /app/ragstuffer/
+COPY common.py docstore.py /app/
+
+USER 1001
+
 CMD ["python3", "-m", "ragstuffer"]


### PR DESCRIPTION
Closes #25
Unblocks aclater/framework-ai-stack#38

## Problem
The CPU Containerfile only installed dependencies but did not COPY the ragstuffer source code. The GHCR image (`ghcr.io/aclater/ragstuffer:main`) could not run standalone — it required host volume mounts for the application code (dev-only pattern).

The CUDA and ROCm Containerfiles already had the correct COPY directives.

## Solution
- `COPY ragstuffer/ /app/ragstuffer/` — the package
- `COPY common.py docstore.py /app/` — root-level modules imported by ragstuffer
- `USER 1001` — non-root execution (matches other rag-suite images)

## Testing
- Built locally: `podman build -f Containerfile -t localhost/ragstuffer:test-25 .`
- Verified standalone: all imports succeed, no volume mounts needed
- 100 tests passing
- CodeRabbit: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image configuration to include application code at build time, eliminating the need for runtime code mounting and simplifying deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->