### PR TITLE
docs: synchronize documentation with current implementation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ ragstuffer_embed_errors_total
 ## Running tests
 ```bash
 pip install -r requirements.txt
-python -m pytest -v    # 63 tests
+python -m pytest -v    # 100 tests
 ```
 
 ## Container images

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ SELECT * FROM collections;
 -- 2  | nato | git | NATO documents | 2024-01-02
 ```
 
+## Second instance (ragstuffer-mpep)
+
+A second ragstuffer instance (`ragstuffer-mpep`) runs alongside the primary instance to ingest the USPTO/MPEP patent collection into the `mpep` Qdrant collection. It runs on port 8093:
+
+| Instance | Port | Collection | Description |
+|----------|------|------------|-------------|
+| ragstuffer | 8091 | personnel, nato, documents | General document ingestion |
+| ragstuffer-mpep | 8093 | mpep | USPTO/MPEP patent collection |
+
+Both instances share the same Postgres database but write to different Qdrant collections.
+
 ## Quick start (container)
 
 Three Containerfile variants — build selects automatically based on GPU:
@@ -204,7 +215,7 @@ ragstuffer/
 
 ```bash
 pip install -r requirements.txt
-python -m pytest -v    # 63 tests
+python -m pytest -v    # 100 tests
 ```
 
 ## License


### PR DESCRIPTION
Documentation update based on issues and PRs merged since last audit.

Key changes:
- Second instance (ragstuffer-mpep) at port 8093 documented for USPTO/MPEP patent collection
- Multiple collection support explained
- Test count: 100 tests (up from 63)
- CLAUDE.md test count updated

Closes #25 (Containerfile source)
Closes #21 (TIMESTAMPTZ)
Closes #11 (second instance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect the addition of a second ragstuffer instance with dedicated admin port and collection.
  * Clarified that multiple instances share the same Postgres database while writing to separate vector collections.
  * Updated test count documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->