### PR TITLE
fix(docs): clarify ragstuffer-mpep deployment location (fixes #28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ SELECT * FROM collections;
 -- 2  | nato | git | NATO documents | 2024-01-02
 ```
 
-## Second instance (ragstuffer-mpep)
+## Multiple instances
 
-A second ragstuffer instance (`ragstuffer-mpep`) runs alongside the primary instance to ingest the USPTO/MPEP patent collection into the `mpep` Qdrant collection. It runs on port 8093:
+The same ragstuffer image can run as multiple instances with different collection configs. The deployment quadlets are managed in [framework-ai-stack](https://github.com/aclater/framework-ai-stack):
 
-| Instance | Port | Collection | Description |
-|----------|------|------------|-------------|
-| ragstuffer | 8091 | personnel, nato, documents | General document ingestion |
-| ragstuffer-mpep | 8093 | mpep | USPTO/MPEP patent collection |
+| Instance | Port | Collection | Quadlet |
+|----------|------|------------|---------|
+| ragstuffer | 8091 | personnel, nato, documents | `framework-ai-stack/quadlets/ragstuffer.container` |
+| ragstuffer-mpep | 8093 | mpep | `framework-ai-stack/quadlets/ragstuffer-mpep.container` |
 
-Both instances share the same Postgres database but write to different Qdrant collections.
+Both instances share the same Postgres database and GHCR image but write to different Qdrant collections. Each instance is configured via environment variables (`QDRANT_COLLECTION`, `RAGSTUFFER_ADMIN_PORT`, `GDRIVE_FOLDER_ID`).
 
 ## Quick start (container)
 


### PR DESCRIPTION
Closes #28

## Problem
CodeRabbit flagged on PR #27 that the README documents a `ragstuffer-mpep` instance but no `ragstuffer-mpep.container` quadlet exists in this repo. The quadlet lives in `framework-ai-stack/quadlets/ragstuffer-mpep.container`.

## Solution
Updated the "Second instance" section to:
- Rename to "Multiple instances" (more accurate)
- Add links to the framework-ai-stack repo where the quadlets live
- Show which quadlet file configures each instance
- Explain the multi-instance pattern (same image, different env config)

## Testing
- 100 tests passing
- CodeRabbit: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify how to run multiple instances of the ragstuffer image concurrently with different collection configurations.
  * Enhanced descriptions of environment variables that control instance behavior and configuration.
  * Improved table layout for clearer reference of instance configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->