### PR TITLE
feat(ci): add SBOM generation and attestation (refs rag-suite#25)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,6 +15,8 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
+  attestations: write
 
 env:
   REGISTRY: ghcr.io
@@ -74,6 +76,7 @@ jobs:
             type=sha,suffix=${{ matrix.suffix }}
 
       - name: Build (PR) / Build & push (main/tag)
+        id: build
         uses: docker/build-push-action@v7.0.0
         with:
           context: .
@@ -81,6 +84,31 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: digest
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0.24.0
+        with:
+          image: ghcr.io/aclater/${{ github.event.repository.name }}:main${{ matrix.suffix }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-artifact: false
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v4.1.0
+        id: attest
+        with:
+          subject-name: ghcr.io/aclater/${{ github.event.repository.name }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: sbom-${{ matrix.variant }}-${{ github.run_id }}
+          path: sbom.spdx.json
+          retention-days: 90
 
   sbom:
     name: SBOM (CycloneDX)


### PR DESCRIPTION
Refs aclater/rag-suite#25

Adds SBOM generation and cryptographic attestation to the container build workflow.

## Changes
- Generates SPDX-format SBOM after container build
- Attaches signed attestation to ghcr.io image
- Uploads SBOM as 90-day build artifact
- Adds id-token: write and attestations: write permissions

## Verification after merge
```bash
gh attestation verify oci://ghcr.io/aclater/ragstuffer:main --owner aclater
```