### PR TITLE
docs: restructure README with linked table of contents (refs #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,60 +2,12 @@
 
 Document ingestion for RAG pipelines. Polls Google Drive, git repos, and web URLs, extracts text, chunks, embeds, and stuffs everything into Qdrant + Postgres for retrieval by [ragpipe](https://github.com/aclater/ragpipe).
 
-## What it does
+## Table of contents
 
-1. **Poll** document sources on a configurable interval (default 15 minutes)
-2. **Download** new/modified documents (Google Drive via service account, git shallow clone, web fetch)
-3. **Extract** text from PDF, DOCX, PPTX, XLSX, HTML, Markdown, plain text — with **title extraction per source type**
-4. **Chunk** with RecursiveCharacterTextSplitter (1024 chars, 128 overlap)
-5. **Persist** chunks to Postgres document store (keyed on deterministic UUID5 from source URI), including title metadata per source
-6. **Embed** via ragpipe's `/v1/embeddings` endpoint (or directly via sentence-transformers with GPU auto-detection)
-7. **Upsert** reference-only payloads to Qdrant (vectors + {doc_id, chunk_id, source, title, created_at})
-
-## Title extraction
-
-Titles are extracted per source type and stored alongside chunk metadata in Postgres, then surfaced by ragpipe in `rag_metadata.cited_chunks[].title`:
-
-| Source type | Title extraction |
-|-------------|------------------|
-| Google Drive (PDF) | PDF metadata `Title` field, or filename without extension |
-| Google Drive (DOCX/PPTX) | Document title from Office metadata, or filename |
-| Google Drive (XLSX) | Sheet name or filename |
-| Google Drive (other) | Filename |
-| git repos | First Markdown heading (`# Title`) in file, or filename |
-| Web URLs | `<title>` tag content, or URL path |
-| Local files | Filename |
-
-Title extraction enables ragpipe to surface document titles in citations without storing full text in Qdrant.
-
-## Multiple collection support
-
-ragstuffer can ingest into multiple Qdrant collections simultaneously. Collections are registered in the `collections` table in Postgres, and each source can target a specific collection via the `COLLECTION` environment variable:
-
-| Environment variable | Description |
-|---------------------|-------------|
-| `QDRANT_COLLECTION` | Single collection name (backward compatible) |
-| `QDRANT_COLLECTIONS` | JSON array of collection names for multi-collection ingest |
-
-The `collections` table tracks collection metadata:
-
-```sql
-SELECT * FROM collections;
--- id | name | source_type | description | created_at
--- 1  | personnel | gdrive | Personnel documents | 2024-01-01
--- 2  | nato | git | NATO documents | 2024-01-02
-```
-
-## Multiple instances
-
-The same ragstuffer image can run as multiple instances with different collection configs. The deployment quadlets are managed in [framework-ai-stack](https://github.com/aclater/framework-ai-stack):
-
-| Instance | Port | Collection | Quadlet |
-|----------|------|------------|---------|
-| ragstuffer | 8091 | personnel, nato, documents | `framework-ai-stack/quadlets/ragstuffer.container` |
-| ragstuffer-mpep | 8093 | mpep | `framework-ai-stack/quadlets/ragstuffer-mpep.container` |
-
-Both instances share the same Postgres database and GHCR image but write to different Qdrant collections. Each instance is configured via environment variables (`QDRANT_COLLECTION`, `RAGSTUFFER_ADMIN_PORT`, `GDRIVE_FOLDER_ID`).
+- [Architecture](docs/architecture.md) — data flow, key design decisions, project structure
+- [Configuration](docs/configuration.md) — environment variables
+- [Admin API](docs/admin-api.md) — endpoints and Prometheus metrics
+- [Title extraction](docs/title-extraction.md) — how titles are extracted per source type
 
 ## Quick start (container)
 
@@ -104,118 +56,11 @@ GDRIVE_FOLDER_ID=your-folder-id ./deploy-remote.sh gpu-host.local target-host.lo
 GDRIVE_FOLDER_ID=your-folder-id ./deploy-remote.sh gpu-host.local
 ```
 
-## Configuration
-
-### Core
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GDRIVE_FOLDER_ID` | — | Google Drive folder to watch |
-| `REPO_SOURCES` | — | JSON list: `[{"url": "...", "glob": "**/*.md"}]` |
-| `WEB_SOURCES` | — | JSON list: `["https://..."]` |
-| `WATCH_INTERVAL_MINUTES` | `15` | Poll interval |
-| `CHUNK_SIZE` | `1024` | Max chunk size (characters) |
-| `CHUNK_OVERLAP` | `128` | Overlap between chunks |
-
-### Storage
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `EMBED_URL` | `http://127.0.0.1:8090/v1/embeddings` | Embedding endpoint (ragpipe) |
-| `QDRANT_URL` | `http://127.0.0.1:6333` | Qdrant endpoint |
-| `QDRANT_COLLECTION` | `documents` | Qdrant collection name |
-| `QDRANT_COLLECTIONS` | — | JSON array of collection names for multi-collection ingest |
-| `DOCSTORE_BACKEND` | `postgres` | `postgres` or `sqlite` |
-| `DOCSTORE_URL` | *(required)* | Postgres connection string |
-
-### Google Drive
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to service account key |
-
-### Admin
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `RAGSTUFFER_ADMIN_PORT` | `8091` | Admin API listen port |
-| `RAGSTUFFER_ADMIN_TOKEN` | *(none)* | Bearer token for admin endpoints (set to secure access) |
-
-### GPU ingestion (`ingest-remote.py`)
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `TARGET_HOST` | `127.0.0.1` | Hostname/IP of Qdrant + Postgres target |
-| `RAGSTUFFER_DEVICE` | *(auto-detect)* | Force device: `cuda`, `xpu`, or `cpu` |
-| `EMBED_MODEL` | `BAAI/bge-base-en-v1.5` | Sentence-transformers model |
-
-GPU auto-detection priority: CUDA (NVIDIA) > ROCm (AMD via HIP) > XPU (Intel) > CPU.
-
-## Admin API
-
-Ragstuffer runs a lightweight admin server for triggering ingestion without waiting for the poll interval and exposing metrics.
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/admin/ingest-now` | POST | Trigger immediate incremental ingestion |
-| `/admin/ingest-full` | POST | Clear state file + trigger full re-ingest of all documents |
-| `/health` | GET | Liveness check |
-| `/metrics` | GET | Prometheus metrics |
-
-```bash
-# Trigger immediate ingestion
-curl -X POST http://localhost:8091/admin/ingest-now -H "Authorization: Bearer <token>"
-
-# Force full re-ingest (re-downloads everything)
-curl -X POST http://localhost:8091/admin/ingest-full -H "Authorization: Bearer <token>"
-```
-
-## Prometheus metrics
-
-```
-# HELP ragstuffer_documents_ingested_total Documents ingested from all sources
-# TYPE ragstuffer_documents_ingested_total counter
-ragstuffer_documents_ingested_total{source="gdrive"} 150
-ragstuffer_documents_ingested_total{source="git"} 42
-ragstuffer_documents_ingested_total{source="web"} 8
-
-# HELP ragstuffer_chunks_created_total Chunks created from ingested documents
-# TYPE ragstuffer_chunks_created_total counter
-ragstuffer_chunks_created_total 3420
-
-# HELP ragstuffer_embed_requests_total Embedding requests sent to ragpipe
-# TYPE ragstuffer_embed_requests_total counter
-ragstuffer_embed_requests_total 200
-
-# HELP ragstuffer_embed_errors_total Embedding request failures
-# TYPE ragstuffer_embed_errors_total counter
-ragstuffer_embed_errors_total 3
-```
-
-## Project structure
-
-```
-ragstuffer/
-  common.py           — shared constants, text extraction, chunking, title extraction, HTML parsing
-  docstore.py         — Postgres/SQLite backends + LRU-cached docstore wrapper
-  ragstuffer/
-    __init__.py      — package marker
-    metrics.py        — Prometheus metrics definitions
-  ragstuffer          — main poll loop, admin server, graceful shutdown (executable)
-  ingest-remote.py    — one-shot GPU ingestion (sentence-transformers)
-  setup.sh            — interactive setup wizard (SA key, folder ID, quadlet)
-  deploy-remote.sh    — deploy ingest-remote.py to a GPU host via ssh
-  quadlets/           — Podman quadlet for systemd integration
-  Containerfile       — UBI10 CPU-only image
-  Containerfile.rocm  — AMD ROCm GPU image
-  Containerfile.cuda  — NVIDIA CUDA GPU image
-```
-
 ## Running tests
 
 ```bash
 pip install -r requirements.txt
-python -m pytest -v    # 100 tests
+python -m pytest -v    # 100+ tests
 ```
 
 ## License

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -1,0 +1,44 @@
+# Admin API
+
+Ragstuffer runs a lightweight admin server for triggering ingestion without waiting for the poll interval and exposing metrics.
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/admin/ingest-now` | POST | Trigger immediate incremental ingestion |
+| `/admin/ingest-full` | POST | Clear state file + trigger full re-ingest of all documents |
+| `/health` | GET | Liveness check |
+| `/metrics` | GET | Prometheus metrics |
+
+## Usage
+
+```bash
+# Trigger immediate ingestion
+curl -X POST http://localhost:8091/admin/ingest-now -H "Authorization: Bearer <token>"
+
+# Force full re-ingest (re-downloads everything)
+curl -X POST http://localhost:8091/admin/ingest-full -H "Authorization: Bearer <token>"
+```
+
+## Prometheus metrics
+
+```
+# HELP ragstuffer_documents_ingested_total Documents ingested from all sources
+# TYPE ragstuffer_documents_ingested_total counter
+ragstuffer_documents_ingested_total{source="gdrive"} 150
+ragstuffer_documents_ingested_total{source="git"} 42
+ragstuffer_documents_ingested_total{source="web"} 8
+
+# HELP ragstuffer_chunks_created_total Chunks created from ingested documents
+# TYPE ragstuffer_chunks_created_total counter
+ragstuffer_chunks_created_total 3420
+
+# HELP ragstuffer_embed_requests_total Embedding requests sent to ragpipe
+# TYPE ragstuffer_embed_requests_total counter
+ragstuffer_embed_requests_total 200
+
+# HELP ragstuffer_embed_errors_total Embedding request failures
+# TYPE ragstuffer_embed_errors_total counter
+ragstuffer_embed_errors_total 3
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,84 @@
+# Architecture
+
+Document ingestion for RAG pipelines. Polls Google Drive, git repos, and web URLs, extracts text, chunks, embeds, and stuffs everything into Qdrant + Postgres for retrieval by [ragpipe](https://github.com/aclater/ragpipe).
+
+## Data flow
+
+```
+Document sources (Google Drive / git / web)
+        ↓ poll + download
+Text extraction (PDF, DOCX, PPTX, XLSX, HTML, Markdown, plain text)
+        ↓ title extraction per source type
+Chunking (RecursiveCharacterTextSplitter, 1024 chars, 128 overlap)
+        ↓
+Embed via ragpipe /v1/embeddings (or sentence-transformers for ingest-remote.py)
+        ↓
+Upsert to Qdrant (vectors + {doc_id, chunk_id, source, title, created_at})
+        ↓
+Persist to Postgres (chunks + titles, keyed by deterministic UUID5 from source URI)
+```
+
+## Key design decisions
+
+- **Deterministic UUID5 keys** from source URI — re-ingest is idempotent
+- **Incremental updates** — only changed documents are re-downloaded
+- **Title extraction per source type** — enables ragpipe to surface document titles in citations
+- **Embedding delegated to ragpipe** (`/v1/embeddings`) in polling mode — no GPU needed for ingestion
+- **`ingest-remote.py`** for bulk GPU-accelerated embedding (sentence-transformers with auto GPU detection)
+- **Multiple collection support** via `QDRANT_COLLECTIONS` JSON env var
+- **Collections registered** in `collections` table in Postgres
+
+## Multiple collection support
+
+ragstuffer can ingest into multiple Qdrant collections simultaneously. Collections are registered in the `collections` table in Postgres, and each source can target a specific collection via the `COLLECTION` environment variable.
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `QDRANT_COLLECTION` | Single collection name (backward compatible) |
+| `QDRANT_COLLECTIONS` | JSON array of collection names for multi-collection ingest |
+
+## Multiple instances
+
+The same ragstuffer image can run as multiple instances with different collection configs. The deployment quadlets are managed in [framework-ai-stack](https://github.com/aclater/framework-ai-stack):
+
+| Instance | Port | Collection | Quadlet |
+|----------|------|------------|---------|
+| ragstuffer | 8091 | personnel, nato, documents | `framework-ai-stack/quadlets/ragstuffer.container` |
+| ragstuffer-mpep | 8093 | mpep | `framework-ai-stack/quadlets/ragstuffer-mpep.container` |
+
+Both instances share the same Postgres database and GHCR image but write to different Qdrant collections. Each instance is configured via environment variables (`QDRANT_COLLECTION`, `RAGSTUFFER_ADMIN_PORT`, `GDRIVE_FOLDER_ID`).
+
+## GPU auto-detection (ingest-remote.py)
+
+Priority: CUDA (NVIDIA) > ROCm (AMD via HIP) > XPU (Intel) > CPU.
+
+```python
+import torch
+if torch.cuda.is_available():
+    device = "cuda"
+elif torch.version.hip:
+    device = "cuda"  # AMD ROCm uses CUDA device in sentence-transformers
+elif torch.xpu.is_available():
+    device = "xpu"
+else:
+    device = "cpu"
+```
+
+## Project structure
+
+```
+ragstuffer/
+  common.py           — shared constants, text extraction, chunking, title extraction, HTML parsing
+  docstore.py         — Postgres/SQLite backends + LRU-cached docstore wrapper
+  ragstuffer/
+    __init__.py      — package marker
+    metrics.py        — Prometheus metrics definitions
+  ragstuffer          — main poll loop, admin server, graceful shutdown (executable)
+  ingest-remote.py    — one-shot GPU ingestion (sentence-transformers)
+  setup.sh            — interactive setup wizard (SA key, folder ID, quadlet)
+  deploy-remote.sh    — deploy ingest-remote.py to a GPU host via ssh
+  quadlets/           — Podman quadlet for systemd integration
+  Containerfile       — UBI10 CPU-only image
+  Containerfile.rocm  — AMD ROCm GPU image
+  Containerfile.cuda  — NVIDIA CUDA GPU image
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,46 @@
+# Configuration
+
+## Core
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GDRIVE_FOLDER_ID` | — | Google Drive folder to watch |
+| `REPO_SOURCES` | — | JSON list: `[{"url": "...", "glob": "**/*.md"}]` |
+| `WEB_SOURCES` | — | JSON list: `["https://..."]` |
+| `WATCH_INTERVAL_MINUTES` | `15` | Poll interval |
+| `CHUNK_SIZE` | `1024` | Max chunk size (characters) |
+| `CHUNK_OVERLAP` | `128` | Overlap between chunks |
+
+## Storage
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EMBED_URL` | `http://127.0.0.1:8090/v1/embeddings` | Embedding endpoint (ragpipe) |
+| `QDRANT_URL` | `http://127.0.0.1:6333` | Qdrant endpoint |
+| `QDRANT_COLLECTION` | `documents` | Qdrant collection name |
+| `QDRANT_COLLECTIONS` | — | JSON array of collection names for multi-collection ingest |
+| `DOCSTORE_BACKEND` | `postgres` | `postgres` or `sqlite` |
+| `DOCSTORE_URL` | *(required)* | Postgres connection string |
+
+## Google Drive
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to service account key |
+
+## Admin
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RAGSTUFFER_ADMIN_PORT` | `8091` | Admin API listen port |
+| `RAGSTUFFER_ADMIN_TOKEN` | *(none)* | Bearer token for admin endpoints (set to secure access) |
+
+## GPU ingestion (`ingest-remote.py`)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TARGET_HOST` | `127.0.0.1` | Hostname/IP of Qdrant + Postgres target |
+| `RAGSTUFFER_DEVICE` | *(auto-detect)* | Force device: `cuda`, `xpu`, or `cpu` |
+| `EMBED_MODEL` | `BAAI/bge-base-en-v1.5` | Sentence-transformers model |
+
+GPU auto-detection priority: CUDA (NVIDIA) > ROCm (AMD via HIP) > XPU (Intel) > CPU.

--- a/docs/title-extraction.md
+++ b/docs/title-extraction.md
@@ -1,0 +1,21 @@
+# Title extraction
+
+Titles are extracted per source type and stored alongside chunk metadata in Postgres, then surfaced by ragpipe in `rag_metadata.cited_chunks[].title`.
+
+Title extraction enables ragpipe to surface document titles in citations without storing full text in Qdrant.
+
+## Title source by format
+
+| Source type | Title extraction |
+|-------------|------------------|
+| Google Drive (PDF) | PDF metadata `Title` field, or filename without extension |
+| Google Drive (DOCX/PPTX) | Document title from Office metadata, or filename |
+| Google Drive (XLSX) | Sheet name or filename |
+| Google Drive (other) | Filename |
+| git repos | First Markdown heading (`# Title`) in file, or filename |
+| Web URLs | `<title>` tag content, or URL path |
+| Local files | Filename |
+
+## How titles are used
+
+Titles are stored in the `documents` table in Postgres alongside chunk metadata. When ragpipe retrieves chunks for a query, it includes the title in `rag_metadata.cited_chunks[].title`, allowing responses to cite documents by their proper titles rather than internal IDs.


### PR DESCRIPTION
Closes #38

## Problem

README had all documentation inline (223 lines), making it difficult to navigate.

## Solution

- Created docs/ directory with structured documentation:
  - docs/architecture.md — data flow, key design decisions, project structure
  - docs/configuration.md — all environment variables
  - docs/admin-api.md — endpoints and Prometheus metrics
  - docs/title-extraction.md — title source by format
- Updated README.md to have linked table of contents and concise quick-start

## Testing

N/A — documentation only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README with dedicated table of contents for improved navigation
  * Added Admin API documentation with endpoint descriptions and usage examples
  * Added architecture documentation detailing the ingestion pipeline and system design
  * Added configuration documentation listing environment variables and settings
  * Added title extraction documentation explaining extraction rules by source type

<!-- end of auto-generated comment: release notes by coderabbit.ai -->