### PR TITLE
docs: add architecture.svg for ingestion pipeline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,8 @@
 
 Document ingestion for RAG pipelines. Polls Google Drive, git repos, and web URLs, extracts text, chunks, embeds, and stuffs everything into Qdrant + Postgres for retrieval by [ragpipe](https://github.com/aclater/ragpipe).
 
+![ragstuffer architecture](architecture.svg)
+
 ## Data flow
 
 ```

--- a/docs/architecture.svg
+++ b/docs/architecture.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 680" width="820" height="680">
+  <style>
+    text { font-family: -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif; fill: currentColor; }
+    .title { font-size: 16px; font-weight: 700; }
+    .label { font-size: 11px; }
+    .label-sm { font-size: 10px; }
+    .port { font-size: 9px; font-weight: 700; }
+    .note { font-size: 9px; opacity: 0.7; }
+    .arrow { stroke: currentColor; stroke-width: 1.5; fill: none; marker-end: url(#arrowhead); }
+    .arrow-dotted { stroke: currentColor; stroke-width: 1.5; fill: none; stroke-dasharray: 5,3; marker-end: url(#arrowhead); }
+    .box { rx: 6; ry: 6; stroke: none; }
+    .box-outline { rx: 6; ry: 6; fill: none; stroke: currentColor; stroke-width: 1; stroke-dasharray: 4,3; opacity: 0.4; }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="8" markerHeight="6" refX="7" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6 Z" fill="currentColor"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="410" y="28" text-anchor="middle" class="title">ragstuffer ingestion pipeline</text>
+
+  <!-- ════════════════ ROW 1: Sources ════════════════ -->
+  <text x="410" y="58" text-anchor="middle" class="label-sm" opacity="0.5">DOCUMENT SOURCES</text>
+
+  <!-- Google Drive -->
+  <rect x="40" y="68" width="210" height="48" class="box" fill="#4ecdc4" opacity="0.85"/>
+  <text x="145" y="88" text-anchor="middle" class="label" fill="#000" font-weight="600">Google Drive</text>
+  <text x="145" y="102" text-anchor="middle" class="label-sm" fill="#000">polling (15 min) + incremental</text>
+
+  <!-- Git Repos -->
+  <rect x="300" y="68" width="210" height="48" class="box" fill="#45b7d1" opacity="0.85"/>
+  <text x="405" y="88" text-anchor="middle" class="label" fill="#000" font-weight="600">Git Repos</text>
+  <text x="405" y="102" text-anchor="middle" class="label-sm" fill="#000">shallow clone / pull --ff-only</text>
+
+  <!-- Web URLs -->
+  <rect x="560" y="68" width="210" height="48" class="box" fill="#ff6b6b" opacity="0.85"/>
+  <text x="665" y="88" text-anchor="middle" class="label" fill="#000" font-weight="600">Web URLs</text>
+  <text x="665" y="102" text-anchor="middle" class="label-sm" fill="#000">HTTP fetch + HTML strip</text>
+
+  <!-- Arrows from sources down -->
+  <line x1="145" y1="116" x2="145" y2="148" class="arrow"/>
+  <line x1="405" y1="116" x2="405" y2="148" class="arrow"/>
+  <line x1="665" y1="116" x2="665" y2="148" class="arrow"/>
+
+  <!-- ════════════════ ROW 2: Text Extraction ════════════════ -->
+  <rect x="60" y="148" width="690" height="52" class="box" fill="#a78bfa" opacity="0.75"/>
+  <text x="405" y="170" text-anchor="middle" class="label" fill="#000" font-weight="600">Text Extraction</text>
+  <text x="405" y="184" text-anchor="middle" class="label-sm" fill="#000">PDF / DOCX / PPTX / XLSX / HTML / Markdown / RST / AsciiDoc / plain text</text>
+
+  <!-- Title extraction callout -->
+  <rect x="565" y="152" width="170" height="20" rx="4" ry="4" fill="#fbbf24" opacity="0.9"/>
+  <text x="650" y="166" text-anchor="middle" class="label-sm" fill="#000">+ title extraction per type</text>
+
+  <!-- Arrow down -->
+  <line x1="405" y1="200" x2="405" y2="228" class="arrow"/>
+
+  <!-- ════════════════ ROW 3: Chunking ════════════════ -->
+  <rect x="175" y="228" width="460" height="44" class="box" fill="#34d399" opacity="0.8"/>
+  <text x="405" y="248" text-anchor="middle" class="label" fill="#000" font-weight="600">Chunking</text>
+  <text x="405" y="262" text-anchor="middle" class="label-sm" fill="#000">RecursiveCharacterTextSplitter (1024 chars, 128 overlap)</text>
+
+  <!-- UUID5 callout -->
+  <rect x="20" y="233" width="140" height="34" rx="4" ry="4" fill="none" stroke="currentColor" stroke-width="1" opacity="0.5"/>
+  <text x="90" y="248" text-anchor="middle" class="label-sm">UUID5 from</text>
+  <text x="90" y="260" text-anchor="middle" class="label-sm">source URI</text>
+  <line x1="160" y1="250" x2="175" y2="250" class="arrow" opacity="0.5"/>
+
+  <!-- Arrow down -->
+  <line x1="405" y1="272" x2="405" y2="300" class="arrow"/>
+
+  <!-- ════════════════ ROW 4: Embedding ════════════════ -->
+  <rect x="175" y="300" width="460" height="48" class="box" fill="#f97316" opacity="0.8"/>
+  <text x="405" y="320" text-anchor="middle" class="label" fill="#000" font-weight="600">Embed via ragpipe /v1/embeddings</text>
+  <text x="405" y="336" text-anchor="middle" class="label-sm" fill="#000">batch_size=64 | 4 concurrent threads | connection pooling</text>
+
+  <!-- ragpipe external service callout -->
+  <rect x="650" y="302" width="140" height="42" class="box" fill="#38bdf8" opacity="0.85"/>
+  <text x="720" y="319" text-anchor="middle" class="label" fill="#000" font-weight="600">ragpipe</text>
+  <text x="720" y="333" text-anchor="middle" class="port" fill="#000">:8090</text>
+  <line x1="635" y1="324" x2="650" y2="324" class="arrow"/>
+
+  <!-- Arrow down splits to two targets -->
+  <line x1="405" y1="348" x2="405" y2="380" class="arrow" style="marker-end: none"/>
+  <!-- Split left -->
+  <line x1="405" y1="380" x2="250" y2="380" style="stroke: currentColor; stroke-width: 1.5; fill: none;"/>
+  <line x1="250" y1="380" x2="250" y2="400" class="arrow"/>
+  <!-- Split right -->
+  <line x1="405" y1="380" x2="560" y2="380" style="stroke: currentColor; stroke-width: 1.5; fill: none;"/>
+  <line x1="560" y1="380" x2="560" y2="400" class="arrow"/>
+
+  <!-- ════════════════ ROW 5: Storage ════════════════ -->
+  <!-- Qdrant -->
+  <rect x="120" y="400" width="260" height="60" class="box" fill="#e879f9" opacity="0.8"/>
+  <text x="250" y="420" text-anchor="middle" class="label" fill="#000" font-weight="600">Qdrant</text>
+  <text x="250" y="434" text-anchor="middle" class="port" fill="#000">:6333</text>
+  <text x="250" y="450" text-anchor="middle" class="label-sm" fill="#000">vectors + {doc_id, chunk_id, source, title}</text>
+
+  <!-- Postgres -->
+  <rect x="430" y="400" width="260" height="60" class="box" fill="#fb923c" opacity="0.8"/>
+  <text x="560" y="420" text-anchor="middle" class="label" fill="#000" font-weight="600">Postgres</text>
+  <text x="560" y="434" text-anchor="middle" class="port" fill="#000">:5432</text>
+  <text x="560" y="450" text-anchor="middle" class="label-sm" fill="#000">chunks + titles (full text)</text>
+
+  <!-- ════════════════ ROW 6: Instances ════════════════ -->
+  <text x="410" y="496" text-anchor="middle" class="label-sm" opacity="0.5">DEPLOYMENT INSTANCES</text>
+
+  <!-- ragstuffer instance -->
+  <rect x="60" y="506" width="320" height="60" class="box" fill="#4ecdc4" opacity="0.65"/>
+  <text x="220" y="526" text-anchor="middle" class="label" fill="#000" font-weight="600">ragstuffer</text>
+  <text x="220" y="540" text-anchor="middle" class="port" fill="#000">:8091</text>
+  <text x="220" y="556" text-anchor="middle" class="label-sm" fill="#000">collections: personnel, nato, documents</text>
+
+  <!-- ragstuffer-mpep instance -->
+  <rect x="430" y="506" width="320" height="60" class="box" fill="#45b7d1" opacity="0.65"/>
+  <text x="590" y="526" text-anchor="middle" class="label" fill="#000" font-weight="600">ragstuffer-mpep</text>
+  <text x="590" y="540" text-anchor="middle" class="port" fill="#000">:8093</text>
+  <text x="590" y="556" text-anchor="middle" class="label-sm" fill="#000">collection: mpep</text>
+
+  <!-- ════════════════ ROW 7: Admin + Metrics ════════════════ -->
+  <!-- Admin API -->
+  <rect x="60" y="590" width="240" height="52" class="box-outline"/>
+  <text x="180" y="610" text-anchor="middle" class="label" font-weight="600">Admin API</text>
+  <text x="180" y="626" text-anchor="middle" class="label-sm">/health  /admin/ingest-now  /admin/ingest-full</text>
+
+  <!-- Prometheus metrics -->
+  <rect x="340" y="590" width="180" height="52" class="box-outline"/>
+  <text x="430" y="610" text-anchor="middle" class="label" font-weight="600">Prometheus /metrics</text>
+  <text x="430" y="626" text-anchor="middle" class="label-sm">docs, chunks, embeds, errors</text>
+
+  <!-- ragwatch -->
+  <rect x="560" y="590" width="180" height="52" class="box" fill="#fbbf24" opacity="0.7"/>
+  <text x="650" y="610" text-anchor="middle" class="label" fill="#000" font-weight="600">ragwatch</text>
+  <text x="650" y="624" text-anchor="middle" class="port" fill="#000">:9090</text>
+  <line x1="520" y1="616" x2="560" y2="616" class="arrow"/>
+
+  <!-- ════════════════ Proposed: ingest-remote.py (dotted) ════════════════ -->
+  <rect x="175" y="656" width="460" height="20" rx="4" ry="4" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
+  <text x="405" y="670" text-anchor="middle" class="note">proposed: ingest-remote.py -- GPU-local embedding (sentence-transformers on ROCm/CUDA/XPU)</text>
+</svg>


### PR DESCRIPTION
## Summary

- Adds `docs/architecture.svg` showing the full ragstuffer ingestion pipeline: three source types (Google Drive, Git, Web), text/title extraction, chunking, embedding delegation to ragpipe, dual storage (Qdrant vectors + Postgres full text), two deployment instances (ragstuffer:8091, ragstuffer-mpep:8093), admin API endpoints, and Prometheus metrics flow to ragwatch
- References the SVG from `docs/architecture.md` with an image embed
- Dark mode compatible: transparent background, `currentColor` for text, colored boxes for pipeline stages

Closes #37

## Test plan

- [x] All 113 existing tests pass (`python -m pytest -v`)
- [ ] Verify SVG renders correctly on GitHub in both light and dark mode
- [ ] Confirm image displays in `docs/architecture.md` preview

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with a visual diagram to enhance clarity of the system design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->