### PR TITLE
fix(quadlet): add UserNS=keep-id so bind-mounted SA key is readable (fixes #41)

### DIFF
--- a/quadlets/ragstuffer.container
+++ b/quadlets/ragstuffer.container
@@ -30,8 +30,13 @@ Environment=GOOGLE_APPLICATION_CREDENTIALS=/run/secrets/gdrive-sa.json
 Environment=RAG_STATE_FILE=/state/rag-state.json
 Environment=STAGING_DIR=/tmp/rag-staging
 
-# Run as non-root
+# Run as non-root. UserNS=keep-id maps host uid 1000 identically into the
+# container so the bind-mounted SA key (0600, owned by host uid 1000) is
+# readable. Without this, rootless Podman maps host uid 1000 to container
+# root, and a User=1000 process sees the mount as an unmapped subuid and
+# is denied by the 0600 mode. See issue #41.
 User=1000
+UserNS=keep-id:uid=1000,gid=1000
 
 # Networking — needs access to Qdrant and ragpipe on the host
 Network=host


### PR DESCRIPTION
Closes #41

## Problem

On a fresh rootless Podman deploy, ragstuffer crashloops on the first Drive poll cycle:

```
PermissionError: [Errno 13] Permission denied: '/run/secrets/gdrive-sa.json'
  File "ragstuffer/__init__.py", line 80, in get_drive_service
```

The quadlet bind-mounts `~/.config/ramalama/gdrive-sa.json` (0600, owned by host uid 1000) and sets `User=1000`. Without a userns override, rootless Podman maps host uid 1000 to container root, so a container-uid-1000 process sees the mount as owned by an unmapped subuid and the 0600 mode denies read.

## Solution

Add `UserNS=keep-id:uid=1000,gid=1000` alongside `User=1000`. With keep-id, host uid 1000 maps identically into the container, and the existing `User=1000` process can read the bind-mounted SA key without any change to host file permissions.

## Testing

Verified on Fedora 43 rootless Podman with the deployed quadlet:

- Before: `PermissionError` on every poll; `podman exec ragstuffer ls -la /run/secrets/gdrive-sa.json` showed `root root` (unmapped).
- After: `id` inside container shows `uid=1000(aclater)`, ls shows `aclater 1000` ownership, Drive poll cycle succeeds (23 new files ingested on first run).

## Reference implementations used

None — standard rootless Podman userns pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container user namespace configuration to improve system compatibility and file permission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->